### PR TITLE
Add TEMPO M3 model to the small molecule library [arXiv:2209.02072]

### DIFF
--- a/new_models/SMILES/TEMPO.smiles
+++ b/new_models/SMILES/TEMPO.smiles
@@ -1,0 +1,1 @@
+CC1(CCCC(N1[O])(C)C)C

--- a/new_models/itps/cog-mono/TEMPO_cog.itp
+++ b/new_models/itps/cog-mono/TEMPO_cog.itp
@@ -1,0 +1,36 @@
+
+;;;;;; TEMPO (2,2,6,6-TETRAMETHYLPIPERIDINE-1-OXYL) 
+;
+; Note(s):
+;   For minimizations, you may use define=-DFLEXIBLE to use a stiff-bond version of the topology that is more amenable to minimization.
+;
+
+[moleculetype]
+; molname       nrexcl
+  TEMPO           1
+
+[atoms]
+; id  type  resnr  residu atom  cgnr  charge
+   1   TP5    1     TEMPO  N1    1     0
+   2   SC3    1     TEMPO  C2    2     0
+   3   SC3    1     TEMPO  C3    3     0
+   4   SC3    1     TEMPO  C4    4     0 
+
+[bonds]
+  2 4       1     0.378   25000 ; cog 
+  3 4       1     0.378   25000 ; cog 
+#ifndef FLEXIBLE
+[constraints]
+#endif
+; i j   funct   length
+  1 2       1     0.238 1000000 ; cog 
+  1 3       1     0.238 1000000 ; cog 
+  1 4       1     0.387 1000000 ; cog 
+
+[dihedrals]
+; i j k l  funct  ref.angle   force_k
+   1 2 3 4    2      180.00      10
+
+[exclusions]
+  1 4
+

--- a/new_models/itps/opt-mono/TEMPO.itp
+++ b/new_models/itps/opt-mono/TEMPO.itp
@@ -1,0 +1,36 @@
+
+;;;;;; TEMPO (2,2,6,6-TETRAMETHYLPIPERIDINE-1-OXYL) 
+;
+; Note(s):
+;   For minimizations, you may use define=-DFLEXIBLE to use a stiff-bond version of the topology that is more amenable to minimization.
+;
+
+[moleculetype]
+; molname       nrexcl
+  TEMPO           1
+
+[atoms]
+; id  type  resnr  residu atom  cgnr  charge
+   1   TP5    1     TEMPO  N1    1     0
+   2   SC3    1     TEMPO  C2    2     0
+   3   SC3    1     TEMPO  C3    3     0
+   4   SC3    1     TEMPO  C4    4     0 
+
+[bonds]
+  2 4       1     0.378   25000 ; cog 
+  3 4       1     0.378   25000 ; cog 
+#ifndef FLEXIBLE
+[constraints]
+#endif
+; i j   funct   length
+  1 2       1     0.238 1000000 ; cog 
+  1 3       1     0.238 1000000 ; cog 
+  1 4       1     0.387 1000000 ; cog 
+
+[dihedrals]
+; i j k l  funct  ref.angle   force_k
+   1 2 3 4    2      180.00      10
+
+[exclusions]
+  1 4
+


### PR DESCRIPTION
Contributing the Martini 3 model developed for [TEMPO](https://pubchem.ncbi.nlm.nih.gov/compound/Tempo) in [arXiv:2209.02072](https://arxiv.org/abs/2209.02072).

Housekeeping note: I created a `new_models/` folder that I don't like because I was unsure whether I should throw the model among the others. Will need to think about it.
